### PR TITLE
introduce :Hostable

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -64,26 +64,33 @@
 
 :Agent a owl:Class ;
        rdfs:comment "An entity that is capable of flexible autonomous behavior."@en ;
-       rdfs:label "Agent"@en, "Agent"@fr.
-
-
+       rdfs:label "Agent"@en, "Agent"@fr ;
+          rdfs:subClassOf :Hostable .
 
 :Artifact a owl:Class ;
           rdfs:comment "An artifact is a resource (or tool) that exposes affordances to agents. Agents use artifacts to achieve their design objectives."@en ;
-          rdfs:label "Artifact"@en, "Artéfact"@en .
+          rdfs:label "Artifact"@en, "Artéfact"@en ;
+          rdfs:subClassOf :Hostable .
 
+
+:Hostable a owl:Class ;
+  rdfs:comment "An entity that can be hosted on a MAS platform"@en ;
+  skos:example "an agent, an artefact, other MAS platforms, workspaces, resource profiles, signifiers, can be hosted on a MAS platform"@en ;
+  rdfs:label "Hostable"@en, "Hébergeable"@fr .
 
 
 :Platform a owl:Class ;
           rdfs:comment "A platform is a system providing a collection of features to support Hypermedia MAS. Common features include support for communication and interaction, runtime environments for agents, artifacts, or organization, etc."@en ;
-          rdfs:label "Platform"@en, "Platforme"@fr .
+          rdfs:label "Platform"@en, "Platforme"@fr ;
+          rdfs:subClassOf :Hostable .
 
 
 
 :ResourceProfile a owl:Class ;
                  rdfs:comment "Structured data describing a resource through general metadata, domain- and application-specific metadata, and signifiers."@en ;
                  skos:example "e.g., a TD document, a Hydra document, an STN platform description, a fipa:AgentPlatformDescription"@en ;
-                 rdfs:label "Resource Profile"@en, "Profil de Resource"@fr .
+                 rdfs:label "Resource Profile"@en, "Profil de Resource"@fr ;
+          rdfs:subClassOf :Hostable .
 
 
 
@@ -98,8 +105,10 @@
 
 
 :Workspace a owl:Class ;
-           rdfs:comment "A space or logical container of one or multiple activities involving a set of agents and potentially artifacts. Workspaces can contain agents, artifacts, and also other workspaces."@en ;
-           rdfs:label "Workspace"@en, "Espace de Travail"@fr .
+   rdfs:comment "A space or logical container of one or multiple activities involving a set of agents and potentially artifacts. Workspaces can contain agents, artifacts, and also other workspaces."@en ;
+   rdfs:label "Workspace"@en, "Espace de Travail"@fr ;
+   rdfs:subClassOf :Hostable .
+
 
 
 ### Top ontology constraints for coherent modeling 
@@ -176,6 +185,7 @@
 :hosts a owl:AsymmetricProperty ;
        owl:inverseOf :isHostedBy ;
        rdfs:domain :Platform ;
+       rdfs:range :Hostable ;
        rdfs:comment "A relation that refers to an information resource or a process (e.g., agent) that is hosted on a platform. A hosting relation might have further implications, e.g. the usage of the hosted resource (or the usage of platform resources by the hosted resource) could be subject to terms of service or data licensing policies specific to the hosting platform."@en ;
        rdfs:label "hosts"@en ;
        dct:source <https://github.com/HyperAgents/ns.hyperagents.org/issues/8#issuecomment-1025991719> ;
@@ -210,7 +220,8 @@
 
 
 
-:isHostedBy a owl:AsymmetricProperty ;
+:isHostedBy a owl:AsymmetricProperty ; 
+            rdfs:domain :Hostable ;
             rdfs:range :Platform ;
             rdfs:comment "A relations that refers to the platform that hosts the resource. "@en ;
             rdfs:label "is hosted by"@en .


### PR DESCRIPTION
Introduce `:Hostable` as range of `:hosts` and common superclass for `:Platform`, `:Workspace`, `:Agent`, `:Artifact`.

Only `:Signifier` is not defined as a sub-class of `:Hostable`.