### PR TITLE
Change base IRI to a PURL IRI [close #69]

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -1,4 +1,4 @@
-@base <https://ci.mines-stetienne.fr/hmas> .
+@base <https://purl.org/hmas/core> .
 @prefix : <#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .


### PR DESCRIPTION
Update the base IRI for the core vocab to: https://purl.org/hmas/core