### PR TITLE
feat: corrected namespaces and added test classes for the automatic generation of redirections

### DIFF
--- a/src/fipa.ttl
+++ b/src/fipa.ttl
@@ -1,4 +1,5 @@
-@prefix hmas: <https://purl.org/hmas/> .
+@base <https://purl.org/hmas/> .
+@prefix : <> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -8,24 +9,24 @@
 
 @base <https://purl.org/hmas/> .
 
-hmas:fipaVocabulary rdf:type owl:Ontology ;
-    owl:imports hmas:core ;
+:fipa rdf:type owl:Ontology ;
+    owl:imports :core ;
     vann:preferredNamespacePrefix "hmas" ;
-    vann:preferredNamespaceUri hmas: .
+    vann:preferredNamespaceUri <> .
 
 #################################################################
 #    Object Properties
 #################################################################
 
 ###  https://ci.mines-stetienne.fr/fipa#hasServiceName
-hmas:hasServiceName rdf:type owl:ObjectProperty ;
-                rdfs:domain hmas:APService ;
+:hasServiceName rdf:type owl:ObjectProperty ;
+                rdfs:domain :APService ;
                 rdfs:label "has Service Name"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#hasServiceType
-hmas:hasServiceType rdf:type owl:ObjectProperty ;
-                rdfs:domain hmas:APService ;
+:hasServiceType rdf:type owl:ObjectProperty ;
+                rdfs:domain :APService ;
                 rdfs:label "has Service Type"@en .
 
 
@@ -34,49 +35,49 @@ hmas:hasServiceType rdf:type owl:ObjectProperty ;
 #################################################################
 
 ###  https://ci.mines-stetienne.fr/fipa#APService
-hmas:APService rdf:type owl:Class ;
+:APService rdf:type owl:Class ;
            rdfs:comment "A service exposed by a FIPA Agent Platform as defined by the FIPA Abstract Architecture Specification (http://fipa.org/specs/fipa00001/SC00001L.html)."@en ;
            rdfs:label "Agent Platform Service"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#AgentIdentifierDescription
-hmas:AgentIdentifierDescription rdf:type owl:Class ;
+:AgentIdentifierDescription rdf:type owl:Class ;
                             rdfs:subClassOf <https://ci.mines-stetienne.fr/hmas#ResourceProfile> ;
                             rdfs:comment "A resource profile that describes an agent using the Agent Identifier Description defined by the FIPA Agent Management Specification (http://fipa.org/specs/fipa00023/SC00023K.html)."@en ;
                             rdfs:label "Agent Identifier Description"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#AgentPlatformDescription
-hmas:AgentPlatformDescription rdf:type owl:Class ;
+:AgentPlatformDescription rdf:type owl:Class ;
                           rdfs:subClassOf <https://ci.mines-stetienne.fr/hmas#ResourceProfile> ;
                           rdfs:comment "A resource profile that descripe a FIPA Agent Platform using the Agent Platform Description defined by the FIPA Agent Management Specification (http://fipa.org/specs/fipa00023/SC00023K.html)."@en ;
                           rdfs:label "Agent Platform Description"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#FIPAAgentPlatform
-hmas:FIPAAgentPlatform rdf:type owl:Class ;
+:FIPAAgentPlatform rdf:type owl:Class ;
                    rdfs:subClassOf <https://ci.mines-stetienne.fr/hmas#Platform> ;
                    rdfs:comment "A platform that conforms to the FIPA Abstract Architecture Specification (http://fipa.org/specs/fipa00001/SC00001L.html)."@en ;
                    rdfs:label "FIPA Agent Platform"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#HTTPMessageTransportService
-hmas:HTTPMessageTransportService rdf:type owl:Class ;
-                             rdfs:subClassOf hmas:MessageTransportService ;
+:HTTPMessageTransportService rdf:type owl:Class ;
+                             rdfs:subClassOf :MessageTransportService ;
                              rdfs:comment "An HTTP-based message transport service that confirms to the FIPA Agent Message Transport Protocol for HTTP Specification (http://fipa.org/specs/fipa00084/SC00084F.html)."@en ;
                              rdfs:label "HTTP Message Transport Service"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#IIOPMessageTransportService
-hmas:IIOPMessageTransportService rdf:type owl:Class ;
-                             rdfs:subClassOf hmas:MessageTransportService ;
+:IIOPMessageTransportService rdf:type owl:Class ;
+                             rdfs:subClassOf :MessageTransportService ;
                              rdfs:comment "An HTTP-based message transport service that confirms to the FIPA Agent Message Transport Protocol for IIOP Specification (http://fipa.org/specs/fipa00075/SC00075G.html)."@en ;
                              rdfs:label "IIOP Message Transport Service"@en .
 
 
 ###  https://ci.mines-stetienne.fr/fipa#MessageTransportService
-hmas:MessageTransportService rdf:type owl:Class ;
-                         rdfs:subClassOf hmas:APService ;
+:MessageTransportService rdf:type owl:Class ;
+                         rdfs:subClassOf :APService ;
                          rdfs:comment "A service for transporting messages among agents that conforms to the FIPA Message Transport Service Specification (http://fipa.org/specs/fipa00067/SC00067F.html)."@en ;
                          rdfs:label "Message Transport Service"@en .
 

--- a/src/interaction.ttl
+++ b/src/interaction.ttl
@@ -1,4 +1,5 @@
-@prefix hmas: <https://purl.org/hmas/> .
+@base <https://purl.org/hmas/> .
+@prefix : <> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -12,13 +13,11 @@
 @prefix dct: <http://purl.org/dc/terms/>.
 @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
 
-@base <https://purl.org/hmas/> .
-
 #################################################################
 #    Ontology Description
 #################################################################
 
-hmas:interaction rdf:type owl:Ontology ;
+:interaction rdf:type owl:Ontology ;
     dct:title "Hypermedia MAS Interaction Ontology"@en, "Ontologie d'Interaction des SMA Hypermédias"@fr ;
     dct:description "An ontology to describe interaction in Hypermedia Multi-Agent Systems."@en,
     "L'ontologie pour décrire l'interaction dans les systèmes multi-agents hypermédias."@fr ;
@@ -28,9 +27,9 @@ hmas:interaction rdf:type owl:Ontology ;
     dct:contributor <https://pod.inrupt.com/andreiciortea/profile/card#me> ;
     dct:contributor <https://pod.inrupt.com/smnmyr/profile/card#me> ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
-    owl:imports hmas:core ;
+    owl:imports :core ;
     vann:preferredNamespacePrefix "hmas" ;
-    vann:preferredNamespaceUri hmas: .
+    vann:preferredNamespaceUri <> .
 
 <https://inria.fr/>
   schema:name "Inria" ;
@@ -64,9 +63,9 @@ hmas:interaction rdf:type owl:Ontology ;
 #    Classes
 #################################################################
 
-hmas:TestInteraction a owl:Class ;
+:TestInteraction a owl:Class ;
   rdfs:comment "testing the redirections"@en ;
-  rdfs:isDefinedBy hmas:interaction .
+  rdfs:isDefinedBy :interaction .
 
 #################################################################
 #    Object Properties

--- a/src/regulation.ttl
+++ b/src/regulation.ttl
@@ -1,4 +1,5 @@
-@prefix hmas: <https://purl.org/hmas/> .
+@base <https://purl.org/hmas/> .
+@prefix : <> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -12,22 +13,20 @@
 @prefix dct: <http://purl.org/dc/terms/>.
 @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
 
-@base <https://purl.org/hmas/> .
-
 #################################################################
 #    Ontology Description
 #################################################################
 
-hmas:regulation rdf:type owl:Ontology ;
+:regulation rdf:type owl:Ontology ;
     dct:title "Hypermedia MAS Regulation Ontology"@en, "Ontologie de Régulation des SMA Hypermédias"@fr ;
     dct:description "An ontology to describe the regulation of Hypermedia Multi-Agent Systems."@en,
     "L'ontologie pour décrire la régulation des systèmes multi-agents hypermédias."@fr ;
     dct:issued "2022-05-01"^^xsd:date ;
     ## dct:contributor <http://ns.inria.fr/fabien.gandon#me> ;
     cc:license <https://creativecommons.org/licenses/by/4.0/> ;
-    owl:imports hmas:core ;
+    owl:imports :core ;
     vann:preferredNamespacePrefix "hmas" ;
-    vann:preferredNamespaceUri hmas: .
+    vann:preferredNamespaceUri <> .
 
 <https://inria.fr/>
   schema:name "Inria" ;
@@ -52,9 +51,9 @@ hmas:regulation rdf:type owl:Ontology ;
 #    Classes
 #################################################################
 
-hmas:TestRegulation a owl:Class ;
+:TestRegulation a owl:Class ;
   rdfs:comment "testing the redirections"@en ;
-  rdfs:isDefinedBy hmas:regulation .
+  rdfs:isDefinedBy :regulation .
 
 
 #################################################################


### PR DESCRIPTION
This pull request corrects:

* the definition of bases and prefixes, 
* the preferred namespace and prefix
* the URLs of the core vocabulary and the different vocabularies. 

Each term that is defined by a vocabulary will now be the subject of a redirection in the generated htaccess file.

For example to enable a redirection from `/hmas/Agent` to `/hmas/core#Agent`, you need to include the following triple in the `core.ttl` vocabulary:

`hmas:Agent rdfs:isDefinedBy hmas:core`

Another example: to enable a redirection from `/hmas/TestInteraction` to `/hmas/interaction#Test`, you need to include the following triple in the `interaction.ttl` vocabulary:

`hmas:Test rdfs:isDefinedBy hmas:interaction`




