### PR TITLE
refactor(interaction) rm Input class

### DIFF
--- a/domains/manufacturing-environments/discover-behavior-specifications/onto.ttl
+++ b/domains/manufacturing-environments/discover-behavior-specifications/onto.ttl
@@ -19,11 +19,6 @@
                    rdfs:comment "A course of action performed by an agent upon exploiting a behavior possibility."@en ;
                    rdfs:label "behavior execution"@en, "exécution du comportement"@fr .
 
-:Input a owl:Class ;
-       rdfs:isDefinedBy :interaction ;
-       rdfs:comment "An input of an action, for example, in the representation of an action execution."@en ;
-       rdfs:label "input"@en, "entrée"@fr .
-
 #################################################################
 #    Object Properties
 #################################################################
@@ -31,7 +26,6 @@
 :hasInput a owl:ObjectProperty ;
               rdfs:isDefinedBy :interaction ;
               rdfs:domain :ActionExecution ;
-              rdfs:range :Input ;
               rdfs:comment "A relation between an action execution and the input that it has."@en ;
               rdfs:label "has input"@en, "a une entrée"@fr .
 

--- a/src/interaction.ttl
+++ b/src/interaction.ttl
@@ -42,11 +42,6 @@
                    rdfs:comment "A course of action performed by an agent upon exploiting a behavior possibility."@en ;
                    rdfs:label "behavior execution"@en, "exécution du comportement"@fr .
 
-:Input a owl:Class ;
-       rdfs:isDefinedBy :interaction ;
-       rdfs:comment "An input of an action, for example, in the representation of an action execution."@en ;
-       rdfs:label "input"@en, "entrée"@fr .
-
 #################################################################
 #    Object Properties
 #################################################################
@@ -54,7 +49,6 @@
 :hasInput a owl:ObjectProperty ;
               rdfs:isDefinedBy :interaction ;
               rdfs:domain :ActionExecution ;
-              rdfs:range :Input ;
               rdfs:comment "A relation between an action execution and the input that it has."@en ;
               rdfs:label "has input"@en, "a une entrée"@fr .
 


### PR DESCRIPTION
Removes the class `hmas:Input` from the Interaction ontology.

See details in issue https://github.com/HyperAgents/hmas/issues/179. 